### PR TITLE
Update smartBanner.ts.  Replace , with ;

### DIFF
--- a/src/smartBanner.ts
+++ b/src/smartBanner.ts
@@ -94,7 +94,7 @@ export class SmartBanner {
       font-family: ${options.fontFamily};
       animation: ${options.animation + ' ' + '0.5s both'};
       font-size: 14px;
-      border-radius: ${options.radius},
+      border-radius: ${options.radius};
       color: ${options.textColor}
     }
     .ml-smartBanner__icon {


### PR DESCRIPTION
While integrating the smart-banner at Rewards Network noticed that border-radius didn't work as expected.  Not a blocker for us.  Fixed the typo.